### PR TITLE
Increased max message size for grpc client stubs.  Set max size for q…

### DIFF
--- a/apps/game_master_start.py
+++ b/apps/game_master_start.py
@@ -1,3 +1,5 @@
+import os
+
 import click
 
 from config import logging_configurator
@@ -5,7 +7,6 @@ from gameserver.pong_server import PongServer
 from injections.providers import GrpcServerProviders
 
 logger = logging_configurator.get_logger(__name__)
-
 
 @click.command()
 def cli():
@@ -17,6 +18,8 @@ def cli():
     pong_server: PongServer = GrpcServerProviders.pong_server()
     pong_server.start_server_blocking()
 
-
 if __name__ == '__main__':
+    # print(os.sched_getaffinity(0))
+    # os.sched_setaffinity(0, [0])
+    # print(os.sched_getaffinity(0))
     cli()

--- a/config/config.ini
+++ b/config/config.ini
@@ -111,11 +111,14 @@ fps_cap = 80
 points_in_match = 10
 
 # this is the number of paddle hits before point is declared a draw
-hits_for_draw = 15
+hits_for_draw = 25
 
 [server_client_communication]
 # if this is true, the game server will block on every frame until both player paddle actions have been received.
 # otherwise, if a paddle action is not received at the onset of a frame, the server will continue the last action.
-block_client_paddle_response = False
+block_client_paddle_response = True
+
+# this is the maximum size the game state buffer can be
+max_game_state_buffer_size = 5
 
 

--- a/config/property_configurator.py
+++ b/config/property_configurator.py
@@ -258,6 +258,10 @@ class ServerClientCommunicationConfig(Config):
     def is_client_response_lock(self) -> bool:
         return Config.get_property_bool('server_client_communication', 'block_client_paddle_response')
 
+    @property
+    def max_game_state_buffer_size(self) -> bool:
+        return Config.get_property_int('server_client_communication', 'max_game_state_buffer_size')
+
 
 game_server_config = GameServerConfig()
 player_config = PlayerConfig()

--- a/gameserver/pong_servicer.py
+++ b/gameserver/pong_servicer.py
@@ -36,15 +36,11 @@ class DefaultPongServicer(gamemaster_pb2_grpc.GameMasterServicer):
             first_game_state = game_state_queue.get()
 
             # now drain the rest
-            following_game_states = [game_state_queue.get_nowait() for _ in range(game_state_queue.qsize())]
+            #following_game_states = [game_state_queue.get_nowait() for _ in range(game_state_queue.qsize())]
+            following_game_states = [game_state_queue.get() for _ in range(game_state_queue.qsize())]
             game_state_buffer = GameStateBuffer()
             game_state_buffer.game_states.append(first_game_state)
             game_state_buffer.game_states.extend(following_game_states)
-
-            # game_state = game_state_queue.get()  # this will block indefinitely
-            # logger.debug(
-            #     "Serving game state to [{}:{}]".format(request.player_name, request.paddle_strategy_name))
-            # yield game_state
             yield game_state_buffer
 
     def register_player(self, request, context):

--- a/injections/providers.py
+++ b/injections/providers.py
@@ -4,6 +4,7 @@ import dependency_injector.containers as containers
 import dependency_injector.providers as providers
 
 from config import property_configurator
+from config.property_configurator import server_client_communication_config
 from gameengine.arena import Arena
 from gameengine.ball_to_ball_collision import BilliardBallCollider
 from gameengine.ball_to_barrier_collision import IncidentAngleRebounder
@@ -100,8 +101,10 @@ class ThreadCommunicationProviders(containers.DeclarativeContainer):
     """
     Container for thread safe communication objects
     """
-    left_game_state_queue = providers.Singleton(Queue)
-    right_game_state_queue = providers.Singleton(Queue)
+    left_game_state_queue = providers.Singleton(Queue,
+                                                maxsize=server_client_communication_config.max_game_state_buffer_size)
+    right_game_state_queue = providers.Singleton(Queue,
+                                                 maxsize=server_client_communication_config.max_game_state_buffer_size)
     left_paddle_action_queue = providers.Singleton(Queue)
     right_paddle_action_queue = providers.Singleton(Queue)
 


### PR DESCRIPTION
The maximum message size for grpc stubs is oddly set to 4MB by default.  Increases this to 100MB.

The game_state_queues now have a configurable maximum size.